### PR TITLE
linear_bgr fixed, to_f32 shortened, unit tests added

### DIFF
--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -5,8 +5,10 @@ def to_f32(img):
     '''Scale the dynamic range to 0.0 - 1.0
 
     Arguments:
-    img: an integer image
+    img: An integer image
     '''
+
+    # No well-defined behavior for decimal values or values less than 0
     try:
         dtype_info = np.iinfo(img.dtype)
         assert dtype_info.min is 0
@@ -24,6 +26,7 @@ def f32_to_bgr(f_img, color=[1, 1, 1]):
     f_img: float32 image to reshape
     '''
 
+    # All inputs should be normalized between 0 and 1
     try:
         assert np.all((f_img >= 0) & (f_img <= 1))
     except AssertionError:

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -169,7 +169,9 @@ def test_color_red(image_1channel, range_all, color_red):
 
 
 def test_color_khaki(image_1channel, range_all, color_khaki):
-    '''Blend an image with one channel, testing khaki color'''
+    '''Blend an image with one channel, testing khaki color
+    Colors of any lightness/chroma should map low uint16 input values to 0
+    '''
 
     expected = np.uint8([
         [[0, 0, 0]],
@@ -185,7 +187,9 @@ def test_color_khaki(image_1channel, range_all, color_khaki):
 
 
 def test_color_khaki_range_low(image_1channel, range_low, color_khaki):
-    '''Blend an image with one channel, testing khaki at low range'''
+    '''Blend an image with one channel, testing khaki at low range
+    Colors of any lightness/chroma should map inputs above threshhold to 0
+    '''
 
     expected = np.uint8([
         [[0, 0, 0]],
@@ -197,7 +201,6 @@ def test_color_khaki_range_low(image_1channel, range_low, color_khaki):
                         colors=[color_khaki],
                         ranges=[range_low])
 
-    print(result)
     np.testing.assert_array_equal(expected, result)
 
 


### PR DESCRIPTION
I [rewrote](https://github.com/sorgerlab/minerva-lib-python/pull/3/files#diff-b4a15c8818fcee8c893d7b67f6fd3b42R90) the `linear_bgr` function to correctly clip such that values above the range are cleared to black instead of simply flattening at the highest value in the range.

I [rewrote](https://github.com/sorgerlab/minerva-lib-python/pull/3/files#diff-b4a15c8818fcee8c893d7b67f6fd3b42R19) the `to_f32` function in a way that is functionally equivalent according to the tests but clearer and shorter.

I added 7 unit tests.
